### PR TITLE
+ readBuffer function

### DIFF
--- a/lib/node-office.js
+++ b/lib/node-office.js
@@ -55,25 +55,29 @@ var NodeOffice = (function () {
     console.log("Parser said:"+event.data);
   }
 
+  var readBuffer = function(buffer){
+    var zipFile = new zip(buffer);
+    var entries = zipFile.getEntries()
+    entries.forEach(function (e) {
+      console.log(e.entryName);
+    });
+    zipFile.extractAllTo(EXTRACT_FOLDER, true);
+    parseDocument(RAW_XMLPATH, function (data) {
+      xml_obj = JSON.parse(data);
+      xml_body = xml_obj["w:document"]["w:body"];
+      next(err, getBodyObject);
+    });
+    worker.postMessage("hi");
+    return xml_body
+  }
+
   //reads file and returns of the file
   var readFile = function (file, next) {
     //extract content of file, first test for open office extension
     fs.exists(file, function (exist) {
       if (exist) {
         if (HasSupportedExtension(file)) {
-          var zipFile = new zip(file);
-          var entries = zipFile.getEntries()
-          entries.forEach(function (e) {
-            console.log(e.entryName);
-          });
-          zipFile.extractAllTo(EXTRACT_FOLDER, true);
-          parseDocument(RAW_XMLPATH, function (data) {
-            xml_obj = JSON.parse(data);
-            xml_body = xml_obj["w:document"]["w:body"];
-            next(err, getBodyObject);
-          });
-          worker.postMessage("hi");
-          return xml_body
+          return readBuffer(file);
         }
       }
       else {
@@ -81,7 +85,7 @@ var NodeOffice = (function () {
         next(err, getBodyObject);
       }
     })
-  }
+  };
 
 
 
@@ -182,7 +186,8 @@ var NodeOffice = (function () {
   }
   //returns API
   return{
-    readFile: readFile
+    readFile: readFile,
+    readBuffer: readBuffer
   }
 
 })()


### PR DESCRIPTION
Added readBuffer funciton, that (may be) can process the raw data of file. This function can help to parse data that we have in variable without getting file again.
Not tested this function because module webworker-threads cannot install on my Windows 10 machine and nodeoffice cannot install again:(

It would be nice if in the nodeoffice module will be .doc files supporting.

Sorry for my bad English.
